### PR TITLE
GitHub Actions - shouldn't do review (limited senders)

### DIFF
--- a/.github/workflows/review-with-limited-senders.yml
+++ b/.github/workflows/review-with-limited-senders.yml
@@ -1,0 +1,23 @@
+name: Review PR (limited senders)
+
+on:
+    pull_request:
+        types:
+            - opened
+
+jobs:
+    reviewOpenedPull:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  repository: 'trolit/Patchron'
+                  ref: 'master'
+
+            - run: npm ci --only=production
+
+            - run: npm start
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # or secrets.PAT
+                  NODE_ENV: 'github'
+                  SENDERS: ['test1']

--- a/testFile.js
+++ b/testFile.js
@@ -1,0 +1,3 @@
+// unmarked comment
+
+module.exports = () => {};


### PR DESCRIPTION
Should only do review when author of PR is user with username "test1" or "test2"
